### PR TITLE
Add APIs for training_event.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ omit =
     manage.py,
     */apps.py,
     TMSFTT/wsgi.py,
+    TMSFTT/urls.py,

--- a/TMSFTT/urls.py
+++ b/TMSFTT/urls.py
@@ -19,7 +19,8 @@ from django.urls import include, path
 
 
 API_URLPATTERNS = [
-    path('', include('auth.urls')),
+    path('auth/', include('auth.urls')),
+    path('training_event/', include('training_event.urls')),
 ]
 
 urlpatterns = [

--- a/auth/tests/tests_views.py
+++ b/auth/tests/tests_views.py
@@ -111,13 +111,12 @@ class TestUserProfileViewSet(APITestCase):
         '''UserProfile should be accessed by GET request.'''
         user_profile = mommy.make(auth.models.UserProfile)
         url = reverse('userprofile-detail', args=(user_profile.pk,))
-        expected_keys = {'id', 'create_time', 'update_time', 'user',
-                         'department', 'age'}
 
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(set(response.data.keys()), expected_keys)
+        self.assertIn('id', response.data)
+        self.assertEqual(response.data['id'], user_profile.id)
 
     def test_update_user_profile(self):
         '''UserProfile should be updated by PATCH request.'''

--- a/training_event/models.py
+++ b/training_event/models.py
@@ -30,8 +30,9 @@ class CampusEvent(AbstractEvent):
     '''Events that are held inside campus.'''
     program = models.ForeignKey(Program, verbose_name=_('培训项目'),
                                 on_delete=models.PROTECT)
-    num_enrolled = models.PositiveSmallIntegerField(verbose_name=_('报名人数'))
-    description = models.TextField(verbose_name=_('活动描述'))
+    num_enrolled = models.PositiveSmallIntegerField(
+        verbose_name=_('报名人数'), default=0)
+    description = models.TextField(verbose_name=_('活动描述'), default='')
 
 
 class OffCampusEvent(AbstractEvent):

--- a/training_event/serializers.py
+++ b/training_event/serializers.py
@@ -1,0 +1,26 @@
+'''Define how to serialize our models.'''
+from rest_framework import serializers
+
+import training_event.models
+
+
+class CampusEventSerializer(serializers.ModelSerializer):
+    '''Indicate how to serialize CampusEvent instance.'''
+    class Meta:
+        model = training_event.models.CampusEvent
+        fields = '__all__'
+        read_only_fields = ('num_enrolled',)
+
+
+class OffCampusEventSerializer(serializers.ModelSerializer):
+    '''Indicate how to serialize OffCampusEvent instance.'''
+    class Meta:
+        model = training_event.models.OffCampusEvent
+        fields = '__all__'
+
+
+class EnrollmentSerailizer(serializers.ModelSerializer):
+    '''Indicate how to serialize Enrollment instance.'''
+    class Meta:
+        model = training_event.models.Enrollment
+        fields = '__all__'

--- a/training_event/tests/tests_serializers.py
+++ b/training_event/tests/tests_serializers.py
@@ -1,0 +1,50 @@
+'''Unit tests for training_event serializers.'''
+from django.test import TestCase
+
+import training_event.serializers as serializers
+import training_event.models as models
+
+
+class TestCampusEventSerializer(TestCase):
+    '''Unit tests for serializer of CampusEvent.'''
+    def test_fields_equal(self):
+        '''Serializer should return fields of CampusEvent correctly.'''
+        campus_event = models.CampusEvent()
+        expected_keys = {
+            'id', 'create_time', 'update_time', 'name', 'time',
+            'location', 'num_hours', 'num_participants',
+            'program', 'num_enrolled', 'description',
+        }
+
+        keys = set(serializers.CampusEventSerializer(
+            campus_event).data.keys())
+        self.assertEqual(keys, expected_keys)
+
+
+class TestOffCampusEventSerializer(TestCase):
+    '''Unit tests for serializer of OffCampusEvent.'''
+    def test_fields_equal(self):
+        '''Serializer should return fields of OffCampusEvent correctly.'''
+        off_campus_event = models.OffCampusEvent()
+        expected_keys = {
+            'id', 'create_time', 'update_time', 'name', 'time',
+            'location', 'num_hours', 'num_participants',
+        }
+
+        keys = set(serializers.OffCampusEventSerializer(
+            off_campus_event).data.keys())
+        self.assertEqual(keys, expected_keys)
+
+
+class TestEnrollmentSerializer(TestCase):
+    '''Unit tests for serializer of Enrollment.'''
+    def test_fields_equal(self):
+        '''Serializer should return fields of Enrollment correctly.'''
+        enrollment = models.Enrollment()
+        expected_keys = {
+            'id', 'create_time', 'campus_event', 'user',
+            'enroll_method', 'is_participated',
+        }
+
+        keys = set(serializers.EnrollmentSerailizer(enrollment).data.keys())
+        self.assertEqual(keys, expected_keys)

--- a/training_event/tests/tests_views.py
+++ b/training_event/tests/tests_views.py
@@ -1,0 +1,220 @@
+'''Unit tests for training_event views.'''
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils.timezone import now
+from model_mommy import mommy
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+import training_program.models
+import training_event.models
+
+
+User = get_user_model()
+
+
+class TestCampusEventViewSet(APITestCase):
+    '''Unit tests for CampusEvent view.'''
+    def test_create_campus_event(self):
+        '''CampusEvent should be created by POST request.'''
+        program = mommy.make(training_program.models.Program)
+        url = reverse('campusevent-list')
+        name = 'event'
+        time = now()
+        location = 'location'
+        num_hours = 10
+        num_participants = 100
+        data = {
+            'name': name,
+            'time': time,
+            'location': location,
+            'num_hours': num_hours,
+            'num_participants': num_participants,
+            'program': program.pk,
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(training_event.models.CampusEvent.objects.count(), 1)
+        self.assertEqual(training_event.models.CampusEvent.objects.get().name,
+                         name)
+
+    def test_list_campus_event(self):
+        '''CampusEvents list should be accessed by GET request.'''
+        url = reverse('campusevent-list')
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_campus_event(self):
+        '''CampusEvent should be deleted by DELETE request.'''
+        campus_event = mommy.make(training_event.models.CampusEvent)
+        url = reverse('campusevent-detail', args=(campus_event.pk,))
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(training_event.models.CampusEvent.objects.count(), 0)
+
+    def test_get_campus_event(self):
+        '''CampusEvent should be accessed by GET request.'''
+        campus_event = mommy.make(training_event.models.CampusEvent)
+        url = reverse('campusevent-detail', args=(campus_event.pk,))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('id', response.data)
+        self.assertEqual(response.data['id'], campus_event.id)
+
+    def test_update_campus_event(self):
+        '''CampusEvent should be updated by PATCH request.'''
+        name0 = 'campus_event0'
+        name1 = 'campus_event1'
+        campus_event = mommy.make(training_event.models.CampusEvent,
+                                  name=name0)
+        url = reverse('campusevent-detail', args=(campus_event.pk,))
+        data = {'name': name1}
+
+        response = self.client.patch(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('name', response.data)
+        self.assertEqual(response.data['name'], name1)
+
+
+class TestOffCampusEventViewSet(APITestCase):
+    '''Unit tests for OffCampusEvent view.'''
+    def test_create_off_campus_event(self):
+        '''OffCampusEvent should be created by POST request.'''
+        url = reverse('offcampusevent-list')
+        name = 'event'
+        time = now()
+        location = 'location'
+        num_hours = 10
+        num_participants = 100
+        data = {
+            'name': name,
+            'time': time,
+            'location': location,
+            'num_hours': num_hours,
+            'num_participants': num_participants,
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            training_event.models.OffCampusEvent.objects.count(), 1)
+        self.assertEqual(
+            training_event.models.OffCampusEvent.objects.get().name, name)
+
+    def test_list_off_campus_event(self):
+        '''OffCampusEvents list should be accessed by GET request.'''
+        url = reverse('offcampusevent-list')
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_off_campus_event(self):
+        '''OffCampusEvent should be deleted by DELETE request.'''
+        off_campus_event = mommy.make(training_event.models.OffCampusEvent)
+        url = reverse('offcampusevent-detail', args=(off_campus_event.pk,))
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(
+            training_event.models.OffCampusEvent.objects.count(), 0)
+
+    def test_get_off_campus_event(self):
+        '''OffCampusEvent should be accessed by GET request.'''
+        off_campus_event = mommy.make(training_event.models.OffCampusEvent)
+        url = reverse('offcampusevent-detail', args=(off_campus_event.pk,))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('id', response.data)
+        self.assertEqual(response.data['id'], off_campus_event.id)
+
+    def test_update_off_campus_event(self):
+        '''OffCampusEvent should be updated by PATCH request.'''
+        name0 = 'off_campus_event0'
+        name1 = 'off_campus_event1'
+        off_campus_event = mommy.make(training_event.models.OffCampusEvent,
+                                      name=name0)
+        url = reverse('offcampusevent-detail', args=(off_campus_event.pk,))
+        data = {'name': name1}
+
+        response = self.client.patch(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('name', response.data)
+        self.assertEqual(response.data['name'], name1)
+
+
+class TestEnrollmentViewSet(APITestCase):
+    '''Unit tests for Enrollment view.'''
+    def test_create_enrollment(self):
+        '''Enrollment should be created by POST request.'''
+        user = mommy.make(User)
+        campus_event = mommy.make(training_event.models.CampusEvent)
+        url = reverse('enrollment-list')
+        data = {
+            'campus_event': campus_event.pk,
+            'user': user.pk,
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            training_event.models.Enrollment.objects.count(), 1)
+        obj = training_event.models.Enrollment.objects.get()
+        self.assertEqual(obj.campus_event.pk, campus_event.pk)
+        self.assertEqual(obj.user.pk, user.pk)
+
+    def test_list_enrollment(self):
+        '''Enrollments list should be accessed by GET request.'''
+        url = reverse('enrollment-list')
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_enrollment(self):
+        '''Enrollment should be deleted by DELETE request.'''
+        enrollment = mommy.make(training_event.models.Enrollment)
+        url = reverse('enrollment-detail', args=(enrollment.pk,))
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(
+            training_event.models.Enrollment.objects.count(), 0)
+
+    def test_get_enrollment(self):
+        '''Enrollment should be accessed by GET request.'''
+        enrollment = mommy.make(training_event.models.Enrollment)
+        url = reverse('enrollment-detail', args=(enrollment.pk,))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('id', response.data)
+        self.assertEqual(response.data['id'], enrollment.id)
+
+    def test_update_enrollment(self):
+        '''Enrollment should NOT be updated by PATCH request.'''
+        enrollment = mommy.make(training_event.models.Enrollment)
+        url = reverse('enrollment-detail', args=(enrollment.pk,))
+        data = {}
+
+        response = self.client.patch(url, data, format='json')
+
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/training_event/urls.py
+++ b/training_event/urls.py
@@ -1,0 +1,12 @@
+'''Register URL routes in training_event module.'''
+from rest_framework import routers
+
+import training_event.views
+
+
+router = routers.SimpleRouter()
+router.register(r'campus-events', training_event.views.CampusEventViewSet)
+router.register(r'off-campus-events',
+                training_event.views.OffCampusEventViewSet)
+router.register(r'enrollments', training_event.views.EnrollmentViewSet)
+urlpatterns = router.urls

--- a/training_event/views.py
+++ b/training_event/views.py
@@ -1,0 +1,31 @@
+'''Provide API views for training_event module.'''
+from rest_framework import mixins, viewsets
+
+import training_event.models
+import training_event.serializers
+
+
+class CampusEventViewSet(viewsets.ModelViewSet):
+    '''Create API views for CampusEvent.'''
+    queryset = training_event.models.CampusEvent.objects.all()
+    serializer_class = training_event.serializers.CampusEventSerializer
+
+
+class OffCampusEventViewSet(viewsets.ModelViewSet):
+    '''Create API views for OffCampusEvent.'''
+    queryset = training_event.models.OffCampusEvent.objects.all()
+    serializer_class = training_event.serializers.OffCampusEventSerializer
+
+
+class EnrollmentViewSet(mixins.CreateModelMixin,
+                        mixins.DestroyModelMixin,
+                        mixins.ListModelMixin,
+                        mixins.RetrieveModelMixin,
+                        viewsets.GenericViewSet):
+    '''Create API views for Enrollment.
+
+    It allows users to create, list, retrieve, destroy their enrollments,
+    but do not allow them to update.
+    '''
+    queryset = training_event.models.Enrollment.objects.all()
+    serializer_class = training_event.serializers.EnrollmentSerailizer


### PR DESCRIPTION
* Add APIs for traing_event module.
* When testing retrieving object, only test a object is retrieved and the object we want is retrieved, instead of the content data of the object, that's what serializer is responsible of.