### PR TITLE
Replace session authentication with JWT authentication.

### DIFF
--- a/TMSFTT/settings.py
+++ b/TMSFTT/settings.py
@@ -44,12 +44,10 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'auth.middleware.JWTAuthenticationMiddleware',
     'django_cas.middleware.CASMiddleware',
 ]
 

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -1,0 +1,51 @@
+'''Middlewares provided by auth module.'''
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.functional import SimpleLazyObject
+from rest_framework_jwt.settings import api_settings
+
+
+User = get_user_model()
+
+
+# pylint: disable=R0903,C0111,R0201
+class JWTAuthenticationMiddleware(MiddlewareMixin):
+    '''Authenticate user by JWT.
+
+    This middleware is used to replace the default AuthenticationMiddleware
+    provided by Django.
+    '''
+
+    # pylint: disable=W0212
+    @staticmethod
+    def _get_user(request, jwt_payload):
+        if not hasattr(request, '_jwt_cached_user'):
+            try:
+                user_id = int(jwt_payload.get('user_id', '-1'))
+                request._jwt_cached_user = User.objects.get(id=user_id)
+            except Exception:  # pylint: disable=W0703
+                request._jwt_cached_user = AnonymousUser()
+        return request._jwt_cached_user
+
+    def _get_token(self, request):
+        authorization = request.META.get('HTTP_AUTHORIZATION', '').split(' ')
+        authorization = dict(zip(authorization[::2], authorization[1::2]))
+        token = authorization.get(api_settings.JWT_AUTH_HEADER_PREFIX,
+                                  None)
+        if token is None:
+            token = request.COOKIES.get(api_settings.JWT_AUTH_COOKIE, None)
+
+        return token
+
+    def process_request(self, request):
+        '''Set request.user if token is valid.'''
+        if hasattr(request, 'user') and not request.user.is_anonymous:
+            return
+        token = self._get_token(request)
+        try:
+            jwt_payload = api_settings.JWT_DECODE_HANDLER(token)
+        except Exception:  # pylint: disable=W0703
+            jwt_payload = {'user_id': '-1'}
+        request.user = SimpleLazyObject(
+            lambda: self._get_user(request, jwt_payload))

--- a/auth/tests/tests_middlewares.py
+++ b/auth/tests/tests_middlewares.py
@@ -1,0 +1,134 @@
+'''Unit tests for auth middlewares.'''
+from unittest.mock import patch, Mock
+from model_mommy import mommy
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework_jwt.settings import api_settings
+
+from auth.middleware import JWTAuthenticationMiddleware
+
+
+User = get_user_model()
+
+
+# pylint: disable=W0212
+class TestJWTAuthenticationMiddleware(TestCase):
+    '''Unit tests for JWTAuthenticationMiddleware.'''
+
+    def setUp(self):
+        self.middleware = JWTAuthenticationMiddleware()
+
+    def test_get_token_none(self):
+        '''Should return None if no token presented.'''
+        request = Mock()
+        request.META = {}
+        request.COOKIES = {}
+
+        token = self.middleware._get_token(request)
+
+        self.assertIsNone(token)
+
+    def test_get_token_from_cookie(self):
+        '''Should return token in cookie if presented.'''
+        expected_token = 'cookie-token'
+        request = Mock()
+        request.META = {}
+        request.COOKIES = {
+            api_settings.JWT_AUTH_COOKIE: expected_token,
+        }
+
+        token = self.middleware._get_token(request)
+
+        self.assertEqual(token, expected_token)
+
+    def test_get_token_from_header(self):
+        '''Should return token in header if presented.'''
+        expected_token = 'header-token'
+        not_expected_token = 'cookie-token'
+        request = Mock()
+        request.META = {
+            'HTTP_AUTHORIZATION': '{} {}'.format(
+                api_settings.JWT_AUTH_HEADER_PREFIX, expected_token,
+            ),
+        }
+        request.COOKIES = {
+            api_settings.JWT_AUTH_COOKIE, not_expected_token,
+        }
+
+        token = self.middleware._get_token(request)
+
+        self.assertEqual(token, expected_token)
+
+    @patch('auth.middleware.JWTAuthenticationMiddleware._get_token')
+    def test_process_request_with_user_set(self, mocked_get_token):
+        '''Should return directly if user is already set.'''
+        request = Mock()
+        request.user.is_anonymous = False
+
+        self.middleware.process_request(request)
+
+        mocked_get_token.assert_not_called()
+
+    @patch('auth.middleware.api_settings.JWT_DECODE_HANDLER')
+    @patch('auth.middleware.JWTAuthenticationMiddleware._get_token')
+    def test_process_request_decode_failed(self, mocked_get_token,
+                                           mocked_decode_handler):
+        '''Should set anonymous user if decode failed.'''
+        mocked_get_token.return_value = None
+        mocked_decode_handler.side_effect = Exception()
+        request = Mock(spec=[])
+
+        self.middleware.process_request(request)
+
+        self.assertTrue(request.user.is_anonymous)
+
+    @patch('auth.middleware.api_settings.JWT_DECODE_HANDLER')
+    @patch('auth.middleware.JWTAuthenticationMiddleware._get_token')
+    def test_process_request_decode_succeed(self, mocked_get_token,
+                                            mocked_decode_handler):
+        '''Should set user if decode succeed.'''
+        user = mommy.make(User)
+        mocked_get_token.return_value = None
+        mocked_decode_handler.return_value = {
+            'user_id': str(user.pk),
+        }
+        request = Mock(spec=[])
+
+        self.middleware.process_request(request)
+
+        self.assertIsInstance(request.user, User)
+        self.assertEqual(request.user.pk, user.pk)
+
+    def test_get_user_with_jwt_cached_user_set(self):
+        '''Should return request._jwt_cached_user if set.'''
+        request = Mock()
+        user = 'user'
+        request._jwt_cached_user = user
+        payload = Mock()
+
+        result = self.middleware._get_user(request, payload)
+
+        payload.get.assert_not_called()
+        self.assertEqual(result, user)
+
+    def test_get_user_no_user_id(self):
+        '''Should return Anonymous user if no user_id presented.'''
+        request = Mock([])
+        payload = {}
+
+        result = self.middleware._get_user(request, payload)
+
+        self.assertTrue(result.is_anonymous)  # pylint: disable=E1101
+
+    def test_get_user(self):
+        '''Should return user if user_id presented.'''
+        user = mommy.make(User)
+        request = Mock([])
+        payload = {
+            'user_id': user.pk,
+        }
+
+        result = self.middleware._get_user(request, payload)
+
+        self.assertIsInstance(result, User)
+        self.assertEqual(result.pk, user.pk)  # pylint: disable=E1101

--- a/django_cas/backends.py
+++ b/django_cas/backends.py
@@ -1,6 +1,7 @@
 """CAS authentication backend"""
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
 
 from django_cas.cas_protocols import CAS_PROTOCOLS
 
@@ -12,9 +13,9 @@ if settings.CAS_VERSION not in CAS_PROTOCOLS:  # pragma: no cover
 CAS_VERIFY = CAS_PROTOCOLS[settings.CAS_VERSION]
 
 
-class CASBackend:  # pylint: disable=R0903
+class CASBackend(ModelBackend):  # pylint: disable=R0903
     """CAS authentication backend"""
-    def authenticate(self, request, ticket, service):  # pylint: disable=R0201
+    def authenticate(self, request, ticket, service):  # pylint: disable=W0221
         """Verifies CAS ticket and gets or creates User object"""
         username, _ = CAS_VERIFY(ticket, service)
         if not username:

--- a/django_cas/tests/tests_views.py
+++ b/django_cas/tests/tests_views.py
@@ -94,7 +94,6 @@ class TestLoginView(APITestCase):
 
         response = self.client.post(url, data, format='json')
 
-        mocked_auth.login.assert_called()
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
 

--- a/django_cas/views.py
+++ b/django_cas/views.py
@@ -43,7 +43,6 @@ class LoginView(APIView):
         user = auth.authenticate(ticket=ticket, service=service_url)
         if user is not None:
             # Generage JWT
-            auth.login(request, user)
             payload = api_settings.JWT_PAYLOAD_HANDLER(user)
             token = api_settings.JWT_ENCODE_HANDLER(payload)
             response_data = api_settings.JWT_RESPONSE_PAYLOAD_HANDLER(
@@ -67,11 +66,11 @@ class LoginView(APIView):
 
 class LogoutView(APIView):
     '''Class-based CAS logout view.'''
+
     def get(self, request):
         '''Log a user out.'''
-        auth.logout(request)
         logout(request)
         next_page = request.GET.get('next', get_redirect_url(request))
         if settings.CAS_LOGOUT_COMPLETELY:
-            return HttpResponseRedirect(get_logout_url(request, next_page))
+            next_page = get_logout_url(request, next_page)
         return HttpResponseRedirect(next_page)


### PR DESCRIPTION
* Remove all middlewares related to session-based authentication. Including:
  * **SessionMiddleware**
  * **AuthenticationMiddleware**
  * **MessageMiddleware**
* Introduce JWTAuthenticationMiddleware: Authenticate user in JWT way, looking for JWT in headers or in cookies.
* Remove calls to auth.login(), since we no longer use authentication provided by Django.