### PR TITLE
Fix JWT decode error in prod environment.

### DIFF
--- a/auth/utils.py
+++ b/auth/utils.py
@@ -13,7 +13,7 @@ def get_user_secret_key(user):
     This way we can invalidate all tokens when the server is restart to ensure
     security.
     '''
-    unhashed_key = '{}.{}.{}'.format(
+    unhashed_key = '{}.{}'.format(
         settings.SECRET_KEY,  # Django secret key
         user.password,  # User password
         ).encode()

--- a/auth/utils.py
+++ b/auth/utils.py
@@ -2,14 +2,8 @@
 import hashlib
 
 from django.conf import settings
-from django.utils.timezone import now
 
 from auth.serializers import UserSerializer
-
-
-# The time when this module was imported
-# In Debug mode, this would be set to 0
-__MODULE_IMPORT_TIME = now() if not settings.DEBUG else 0
 
 
 def get_user_secret_key(user):
@@ -22,7 +16,6 @@ def get_user_secret_key(user):
     unhashed_key = '{}.{}.{}'.format(
         settings.SECRET_KEY,  # Django secret key
         user.password,  # User password
-        __MODULE_IMPORT_TIME,
         ).encode()
     sha1 = hashlib.new('sha1')
     sha1.update(unhashed_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,5 +51,6 @@ sqlparse==0.2.4
 text-unidecode==1.2
 uritemplate==3.0.0
 urllib3==1.24.1
+uWSGI==2.0.18
 vine==1.2.0
 wrapt==1.11.0


### PR DESCRIPTION
Due to different start time for multiple processes spawned by uWSGI, the JWT decode process will high likely fail when requests are sent to different processes, remove the const `__MODULE_IMPORT_TIME` to avoid this bug.