### PR TITLE
Return full download url.

### DIFF
--- a/secure_file/tests/tests_models.py
+++ b/secure_file/tests/tests_models.py
@@ -2,6 +2,7 @@
 import os
 import tempfile
 from unittest.mock import patch, Mock
+from urllib.parse import urlunsplit
 
 from django.test import TestCase
 from django.contrib.auth import get_user_model
@@ -35,16 +36,31 @@ class TestSecureFile(TestCase):
         secure_file = SecureFile.from_path(self.user, 'fname', in_memory_file)
         self.assertEqual(secure_file.path.read(), content)
 
+    @patch('secure_file.models.get_current_site')
     @patch('secure_file.models.encrypt_file_download_url')
-    def test_generate_secured_download_response(self, mocked_encrypt):
+    def test_generate_secured_download_response(
+            self, mocked_encrypt, mocked_get_current_site):
         '''Should generate response for redirecting to download.'''
         secure_file = SecureFile()
         secure_file.path = Mock()
         path = 'path/to/file'
         secure_file.path.name = path
-        encrypted_path = '/media/Encrypted'
-        mocked_encrypt.return_value = encrypted_path
-        resp = secure_file.generate_secured_download_response()
+        encrypted_url = '/media/Encrypted'
+        current_site = Mock()
+        current_site.domain = 'http://localhost:8000'
+        mocked_encrypt.return_value = encrypted_url
+        mocked_get_current_site.return_value = current_site
+        request = Mock()
+        request.scheme = 'http'
+        expected_url = urlunsplit((
+            request.scheme,  # URL scheme specifier
+            current_site.domain,  # Network location part
+            encrypted_url,  # Hierarchical path
+            '',  # Query component
+            ''  # Fragment identifier
+        ))
+
+        resp = secure_file.generate_secured_download_response(request)
 
         mocked_encrypt.assert_called_with(
             SecureFile, 'path', path, 'download_file'
@@ -52,4 +68,4 @@ class TestSecureFile(TestCase):
 
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.assertIn('url', resp.data)
-        self.assertEqual(resp.data['url'], encrypted_path)
+        self.assertEqual(resp.data['url'], expected_url)


### PR DESCRIPTION
In order to open a new window to download the file and reduce work on FE side to create a full URL, now we return a full url (instead of only path component) for downloading.