### PR TITLE
Huihua/feature review button visible or not

### DIFF
--- a/training_record/serializers.py
+++ b/training_record/serializers.py
@@ -64,6 +64,9 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
     role = serializers.IntegerField(
         source='event_coefficient.role',
         read_only=True)
+    allow_ordinary_user_review = serializers.BooleanField(read_only=True, default=False)
+    allow_department_admin_review = serializers.BooleanField(read_only=True, default=False)
+    allow_school_admin_review = serializers.BooleanField(read_only=True, default=False)
     off_campus_event = OffCampusEventSerializer(read_only=True)
     campus_event = BasicReadOnlyCampusEventSerializer(read_only=True)
 
@@ -71,7 +74,9 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
         model = Record
         fields = ('id', 'create_time', 'update_time', 'campus_event',
                   'off_campus_event', 'user', 'status', 'contents',
-                  'attachments', 'status_str', 'feedback', 'role', 'role_str')
+                  'attachments', 'status_str', 'feedback', 'role', 'role_str',
+                  'allow_department_admin_review', 'allow_school_admin_review',
+                  'allow_ordinary_user_review')
 
 
 class RecordCreateSerializer(serializers.ModelSerializer):

--- a/training_record/serializers.py
+++ b/training_record/serializers.py
@@ -64,9 +64,12 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
     role = serializers.IntegerField(
         source='event_coefficient.role',
         read_only=True)
-    allow_ordinary_user_review = serializers.BooleanField(read_only=True, default=False)
-    allow_department_admin_review = serializers.BooleanField(read_only=True, default=False)
-    allow_school_admin_review = serializers.BooleanField(read_only=True, default=False)
+    allow_ordinary_user_review = serializers.BooleanField(read_only=True,
+                                                          default=False)
+    allow_department_admin_review = (
+        serializers.SerializerMethodField(read_only=True))
+    allow_school_admin_review = (
+        serializers.SerializerMethodField(read_only=True))
     off_campus_event = OffCampusEventSerializer(read_only=True)
     campus_event = BasicReadOnlyCampusEventSerializer(read_only=True)
 
@@ -77,6 +80,14 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
                   'attachments', 'status_str', 'feedback', 'role', 'role_str',
                   'allow_department_admin_review', 'allow_school_admin_review',
                   'allow_ordinary_user_review')
+
+    def get_allow_department_admin_review(self, obj):
+        '''Get status of whether department admin can review or not.'''
+        return obj.status == Record.STATUS_SUBMITTED
+
+    def get_allow_school_admin_review(self, obj):
+        '''Get status of whether school admin can review or not.'''
+        return obj.status == Record.STATUS_DEPARTMENT_ADMIN_APPROVED
 
 
 class RecordCreateSerializer(serializers.ModelSerializer):

--- a/training_record/serializers.py
+++ b/training_record/serializers.py
@@ -86,6 +86,7 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
         '''Get status of whether ordinary user can edit record or not.'''
         allow_user_action_status = (
             Record.STATUS_SUBMITTED,
+            Record.STATUS_DEPARTMENT_ADMIN_APPROVED,
             Record.STATUS_DEPARTMENT_ADMIN_REJECTED,
             Record.STATUS_SCHOOL_ADMIN_REJECTED
         )

--- a/training_record/serializers.py
+++ b/training_record/serializers.py
@@ -64,11 +64,11 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
     role = serializers.IntegerField(
         source='event_coefficient.role',
         read_only=True)
-    allow_ordinary_user_review = serializers.BooleanField(read_only=True,
-                                                          default=False)
-    allow_department_admin_review = (
+    allow_actions_from_user = serializers.BooleanField(read_only=True,
+                                                       default=False)
+    allow_actions_from_department_admin = (
         serializers.SerializerMethodField(read_only=True))
-    allow_school_admin_review = (
+    allow_actions_from_school_admin = (
         serializers.SerializerMethodField(read_only=True))
     off_campus_event = OffCampusEventSerializer(read_only=True)
     campus_event = BasicReadOnlyCampusEventSerializer(read_only=True)
@@ -78,16 +78,27 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
         fields = ('id', 'create_time', 'update_time', 'campus_event',
                   'off_campus_event', 'user', 'status', 'contents',
                   'attachments', 'status_str', 'feedback', 'role', 'role_str',
-                  'allow_department_admin_review', 'allow_school_admin_review',
-                  'allow_ordinary_user_review')
+                  'allow_actions_from_user',
+                  'allow_actions_from_department_admin',
+                  'allow_actions_from_school_admin')
 
-    def get_allow_department_admin_review(self, obj):
+    def get_allow_actions_from_department_admin(self, obj):
         '''Get status of whether department admin can review or not.'''
-        return obj.status == Record.STATUS_SUBMITTED
+        allow_department_action_status = (
+            Record.STATUS_SUBMITTED,
+            Record.STATUS_DEPARTMENT_ADMIN_APPROVED,
+            Record.STATUS_DEPARTMENT_ADMIN_REJECTED
+        )
+        return obj.status in allow_department_action_status
 
-    def get_allow_school_admin_review(self, obj):
+    def get_allow_actions_from_school_admin(self, obj):
         '''Get status of whether school admin can review or not.'''
-        return obj.status == Record.STATUS_DEPARTMENT_ADMIN_APPROVED
+        allow_school_action_status = (
+            Record.STATUS_DEPARTMENT_ADMIN_APPROVED,
+            Record.STATUS_SCHOOL_ADMIN_APPROVED,
+            Record.STATUS_SCHOOL_ADMIN_REJECTED,
+        )
+        return obj.status in allow_school_action_status
 
 
 class RecordCreateSerializer(serializers.ModelSerializer):

--- a/training_record/serializers.py
+++ b/training_record/serializers.py
@@ -64,8 +64,8 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
     role = serializers.IntegerField(
         source='event_coefficient.role',
         read_only=True)
-    allow_actions_from_user = serializers.BooleanField(read_only=True,
-                                                       default=False)
+    allow_actions_from_user = (
+        serializers.SerializerMethodField(read_only=True))
     allow_actions_from_department_admin = (
         serializers.SerializerMethodField(read_only=True))
     allow_actions_from_school_admin = (
@@ -81,6 +81,15 @@ class ReadOnlyRecordSerializer(serializers.ModelSerializer):
                   'allow_actions_from_user',
                   'allow_actions_from_department_admin',
                   'allow_actions_from_school_admin')
+
+    def get_allow_actions_from_user(self, obj):
+        '''Get status of whether ordinary user can edit record or not.'''
+        allow_user_action_status = (
+            Record.STATUS_SUBMITTED,
+            Record.STATUS_DEPARTMENT_ADMIN_REJECTED,
+            Record.STATUS_SCHOOL_ADMIN_REJECTED
+        )
+        return obj.status in allow_user_action_status
 
     def get_allow_actions_from_department_admin(self, obj):
         '''Get status of whether department admin can review or not.'''

--- a/training_record/tests/tests_views.py
+++ b/training_record/tests/tests_views.py
@@ -150,8 +150,7 @@ class TestRecordViewSet(APITestCase):
                          'off_campus_event', 'user', 'status', 'contents',
                          'attachments', 'status_str', 'role', 'role_str',
                          'feedback', 'allow_actions_from_user',
-                         'allow_actions_from_department_admin',
-                         'allow_actions_from_school_admin'}
+                         'allow_actions_from_admin'}
         PermissionService.assign_object_permissions(self.user, record)
         response = self.client.get(url)
 

--- a/training_record/tests/tests_views.py
+++ b/training_record/tests/tests_views.py
@@ -149,7 +149,9 @@ class TestRecordViewSet(APITestCase):
         expected_keys = {'id', 'create_time', 'update_time', 'campus_event',
                          'off_campus_event', 'user', 'status', 'contents',
                          'attachments', 'status_str', 'role', 'role_str',
-                         'feedback'}
+                         'feedback', 'allow_department_admin_review',
+                         'allow_school_admin_review',
+                         'allow_ordinary_user_review'}
         PermissionService.assign_object_permissions(self.user, record)
         response = self.client.get(url)
 

--- a/training_record/tests/tests_views.py
+++ b/training_record/tests/tests_views.py
@@ -149,9 +149,9 @@ class TestRecordViewSet(APITestCase):
         expected_keys = {'id', 'create_time', 'update_time', 'campus_event',
                          'off_campus_event', 'user', 'status', 'contents',
                          'attachments', 'status_str', 'role', 'role_str',
-                         'feedback', 'allow_department_admin_review',
-                         'allow_school_admin_review',
-                         'allow_ordinary_user_review'}
+                         'feedback', 'allow_actions_from_user',
+                         'allow_actions_from_department_admin',
+                         'allow_actions_from_school_admin'}
         PermissionService.assign_object_permissions(self.user, record)
         response = self.client.get(url)
 

--- a/training_record/utils.py
+++ b/training_record/utils.py
@@ -22,9 +22,7 @@ def is_user_allowed_operating(request, obj):
         record_models.Record.STATUS_DEPARTMENT_ADMIN_REJECTED,
         record_models.Record.STATUS_SCHOOL_ADMIN_REJECTED
     )
-    if (request.user == obj.user) and (obj.status in user_action_status):
-        return True
-    return False
+    return request.user == obj.user and obj.status in user_action_status
 
 
 def is_admin_allowed_operating(request, obj):
@@ -48,6 +46,4 @@ def is_admin_allowed_operating(request, obj):
         request.user.is_school_admin
         and (obj.status in school_admin_action_status)
     )
-    if is_department_admin_allowed or is_school_admin_allowed:
-        return True
-    return False
+    return is_department_admin_allowed or is_school_admin_allowed

--- a/training_record/utils.py
+++ b/training_record/utils.py
@@ -12,3 +12,42 @@ def infer_attachment_type(fname):
     if re.search(r'反馈', fname):
         return record_models.RecordAttachment.ATTACHMENT_TYPE_FEEDBACK
     return record_models.RecordAttachment.ATTACHMENT_TYPE_OTHERS
+
+
+def is_user_allowed_operating(request, obj):
+    '''Check if users can operate.'''
+    import training_record.models as record_models
+    user_action_status = (
+        record_models.Record.STATUS_SUBMITTED,
+        record_models.Record.STATUS_DEPARTMENT_ADMIN_REJECTED,
+        record_models.Record.STATUS_SCHOOL_ADMIN_REJECTED
+    )
+    if (request.user == obj.user) and (obj.status in user_action_status):
+        return True
+    return False
+
+
+def is_admin_allowed_operating(request, obj):
+    '''Check if admin can operate.'''
+    import training_record.models as record_models
+    department_admin_action_status = (
+        record_models.Record.STATUS_SUBMITTED,
+        record_models.Record.STATUS_DEPARTMENT_ADMIN_APPROVED,
+        record_models.Record.STATUS_DEPARTMENT_ADMIN_REJECTED
+    )
+    school_admin_action_status = (
+        record_models.Record.STATUS_DEPARTMENT_ADMIN_APPROVED,
+        record_models.Record.STATUS_SCHOOL_ADMIN_APPROVED,
+        record_models.Record.STATUS_SCHOOL_ADMIN_REJECTED
+    )
+    is_department_admin_allowed = (
+        request.user.is_department_admin
+        and (obj.status in department_admin_action_status)
+    )
+    is_school_admin_allowed = (
+        request.user.is_school_admin
+        and (obj.status in school_admin_action_status)
+    )
+    if is_department_admin_allowed or is_school_admin_allowed:
+        return True
+    return False


### PR DESCRIPTION
In the serializer, I add three extra fields to describe whether ordianry user, department admin or school admin has the permissions to see the review button. Ordinary users will never see the buttons. As for admins, when admin change the record status successfully, they should not see the review buttons again as well.